### PR TITLE
Inject tracing headers into request headers

### DIFF
--- a/src/main/java/com/workiva/eva/client/EvaContext.java
+++ b/src/main/java/com/workiva/eva/client/EvaContext.java
@@ -14,6 +14,10 @@
 
 package com.workiva.eva.client;
 
+import io.opentracing.SpanContext;
+import io.opentracing.propagation.Format;
+import io.opentracing.util.GlobalTracer;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,8 +28,7 @@ public class EvaContext {
   private static final Logger LOGGER = LoggerFactory.getLogger(EvaContext.class);
 
   private final String correlationId;
-  // TODO - add Open Tracing Support
-  // private SpanContext spanContext;
+  private SpanContext spanContext;
 
   public EvaContext() {
     this(UUID.randomUUID().toString());
@@ -37,30 +40,30 @@ public class EvaContext {
   }
 
   public EvaContext(String correlationId) {
-    this.correlationId = correlationId;
+      this.correlationId = correlationId;
   }
 
-  // TODO - add Open Tracing Support
-  // public EvaContext(String correlationId, SpanContext spanContext) {
-  //   this.correlationId = correlationId;
-  //   setSpanContext(spanContext);
-  // }
+  public EvaContext(String correlationId, SpanContext spanContext) {
+    this(correlationId);
+    setSpanContext(spanContext);
+  }
 
   public String getCorrelationId() {
     return correlationId;
   }
 
-  // TODO - add Open Tracing Support
-  // public void setSpanContext(SpanContext spanContext) {
-  //   this.spanContext = spanContext;
-  // }
+  public void setSpanContext(SpanContext spanContext) {
+    this.spanContext = spanContext;
+  }
 
-  // public SpanContext getSpanContext() {
-  //   return spanContext;
-  // }
+  public SpanContext getSpanContext() {
+    return spanContext;
+  }
 
-  // TODO - inject tracing headers into request using JaegerTracing
-  // public void addTracingHeaders(HttpRequestBase request) {
-  //   return;
-  // }
+  void addTracingHeaders(HttpRequestBase request) {
+    if (spanContext != null) {
+      GlobalTracer.get()
+          .inject(spanContext, Format.Builtin.HTTP_HEADERS, new HttpTracingCarrier(request));
+    }
+  }
 }

--- a/src/main/java/com/workiva/eva/client/EvaContext.java
+++ b/src/main/java/com/workiva/eva/client/EvaContext.java
@@ -40,7 +40,7 @@ public class EvaContext {
   }
 
   public EvaContext(String correlationId) {
-      this.correlationId = correlationId;
+    this.correlationId = correlationId;
   }
 
   public EvaContext(String correlationId, SpanContext spanContext) {

--- a/src/main/java/com/workiva/eva/client/EvaHttpClientHelper.java
+++ b/src/main/java/com/workiva/eva/client/EvaHttpClientHelper.java
@@ -120,7 +120,7 @@ public class EvaHttpClientHelper implements EvaClientHelper {
   private void addHeaders(EvaContext context, List<Header> headers, HttpRequestBase request) {
 
     request.setHeader(CORRELATION_ID_HEADER, context.getCorrelationId());
-    // context.addTracingHeaders(request);
+    context.addTracingHeaders(request);
     requestMiddleware(request);
 
     headers.forEach((h) -> request.setHeader(h));

--- a/src/main/java/com/workiva/eva/client/HttpTracingCarrier.java
+++ b/src/main/java/com/workiva/eva/client/HttpTracingCarrier.java
@@ -1,0 +1,27 @@
+package com.workiva.eva.client;
+
+import org.apache.http.client.methods.HttpRequestBase;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Used to inject Tracing spans into request headers.
+ * This only supports injecting tracing headers into the request header, and not extracting.
+ */
+class HttpTracingCarrier implements io.opentracing.propagation.TextMap {
+  HttpRequestBase requestBase;
+
+  HttpTracingCarrier(HttpRequestBase requestBase) {
+    this.requestBase = requestBase;
+  }
+
+  public void put(String key, String val) {
+    requestBase.setHeader(key, val);
+  }
+
+  @Override
+  public Iterator<Map.Entry<String, String>> iterator() {
+    throw new UnsupportedOperationException("Carrier can only be used for writes.");
+  }
+}

--- a/src/main/java/com/workiva/eva/client/HttpTracingCarrier.java
+++ b/src/main/java/com/workiva/eva/client/HttpTracingCarrier.java
@@ -6,8 +6,8 @@ import java.util.Iterator;
 import java.util.Map;
 
 /**
- * Used to inject Tracing spans into request headers.
- * This only supports injecting tracing headers into the request header, and not extracting.
+ * Used to inject Tracing spans into request headers. This only supports injecting tracing headers
+ * into the request header, and not extracting.
  */
 class HttpTracingCarrier implements io.opentracing.propagation.TextMap {
   HttpRequestBase requestBase;

--- a/src/main/java/com/workiva/eva/client/RequestBuilder.java
+++ b/src/main/java/com/workiva/eva/client/RequestBuilder.java
@@ -70,8 +70,7 @@ public abstract class RequestBuilder<T extends RequestBuilder<T, V>, V> {
   protected EvaContext buildContext() {
     if (correlationId == null) {
       ctx = new EvaContext();
-      // TODO - opentracing
-      // ctx.setSpanContext(spanContext);
+       ctx.setSpanContext(spanContext);
     } else {
       ctx = new EvaContext(correlationId);
     }

--- a/src/main/java/com/workiva/eva/client/RequestBuilder.java
+++ b/src/main/java/com/workiva/eva/client/RequestBuilder.java
@@ -70,7 +70,7 @@ public abstract class RequestBuilder<T extends RequestBuilder<T, V>, V> {
   protected EvaContext buildContext() {
     if (correlationId == null) {
       ctx = new EvaContext();
-       ctx.setSpanContext(spanContext);
+      ctx.setSpanContext(spanContext);
     } else {
       ctx = new EvaContext(correlationId);
     }

--- a/src/test/java/examples/eva101/Eva101.java
+++ b/src/test/java/examples/eva101/Eva101.java
@@ -75,12 +75,12 @@ public class Eva101 {
       System.out.println("basis-t: " + afterDb.basisT());
       System.out.println("snapshot-t: " + afterDb.snapshotT());
 
-      // Eva Client Service supports tracing via Jaeger, if you set and use a Jaeger tracer as shown below, you can
+      // Eva Client Service supports tracing via Jaeger, if you set and use a Jaeger tracer as shown
+      // below, you can
       // connect your traces to the Eva Client Service's traces.
       // JaegerTracer tracer = new JaegerTracer.Builder("Eva Client Java Example").build();
       // GlobalTracer.register(tracer);
       Tracer tracer = GlobalTracer.get();
-
 
       // Add First Book
       Span span = tracer.buildSpan("add-first-book").start();
@@ -254,10 +254,7 @@ public class Eva101 {
       result = db.ident(1);
       System.out.println("ident results: " + result);
 
-      result =
-          new LatestTBuilder(conn)
-              .withCorrelationId("latestT")
-              .execute();
+      result = new LatestTBuilder(conn).withCorrelationId("latestT").execute();
       System.out.println("latestT results: " + result);
 
       // Ident and Entid endpoints


### PR DESCRIPTION
Eva Client Service has tracing using Jaeger Tracing. Allow span contexts to be passed in and added to request headers so traces can connect from clients to the Eva client service.